### PR TITLE
Better get out of the way

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -36,4 +36,5 @@ initHarvester(store);
 
 export function loop() {
   store.dispatch({ type: LOOP });
+  Creep.getOutOfTheWay();
 }


### PR DESCRIPTION
Improved get out the way code:

![smart get out of the way](https://user-images.githubusercontent.com/4467892/50391355-54c7ef80-0709-11e9-90c0-fa00a2229cb1.gif)

 - Hooks into `moveTo` and `routeTo`
 - Creeps that are not moving will get out of the way of creeps that are moving
 - Creeps that are moving are excluded
 - Creeps will recursively push other creeps out of the way

To work optimally, creeps should maintain a `creep.memory.target` and `creep.memory.range` state.  `target` can either be a game object ID or a room position array in the form `[x, y]` or `[x, y, roomName]`.  If `range` is undefined it is assumed to be 1.  If these values are set in creep memory, then the creep will look for a position that keeps it in range of its target.  Otherwise it will look for an unoccupied position.